### PR TITLE
Make test output more user friendly

### DIFF
--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -194,8 +194,23 @@ code {
 
 /* @begin JUnit view styles */
 .testcase-list {
-  padding: 0 2rem;
+  padding: 0 2rem 2rem;
+  list-style-type: none;
 }
+
+.inline {
+  display: inline;
+}
+
+.disguised:hover, .disguised:visited, .disguised:link, .disguised:active {
+  text-decoration: none;
+  color: inherit;
+}
+
+.testcase-list .glyphicon {
+  padding-right: 1rem;
+}
+
 /* @end */
 
 /* @begin Badge superscript style*/
@@ -282,6 +297,8 @@ code {
 
 .darken-logo:hover {
   filter: brightness(1.0);
+}
+
 .no-margin-top {
   margin-top: 0;
 }

--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -181,6 +181,10 @@ code {
 .console-output code {
   white-space: pre;
 }
+
+.stacktrace {
+  margin: 10px 0;
+}
 /* @end */
 
 /* @begin <img> styles */

--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -202,7 +202,10 @@ code {
   display: inline;
 }
 
-.disguised:hover, .disguised:visited, .disguised:link, .disguised:active {
+.disguised:hover,
+.disguised:visited,
+.disguised:link,
+.disguised:active {
   text-decoration: none;
   color: inherit;
 }

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -6,12 +6,12 @@
   <div class="bottom-spaced">
   <h4 class="inline">{{ testsuite.name }} (passed {{ testsuite.passed }} of {{ testsuite.total }})</h4>
   {% if testsuite.system_out %}
-    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggleSystemOut{{ forloop.counter }}">
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#stdout-{{ forloop.counter }}">
       <code class="inline">System.out</code>
     </a>
   {% endif %}
   {% if testsuite.system_err %}
-    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggleSystemErr{{ forloop.counter }}">
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#stderr-{{ forloop.counter }}">
       <code class="inline">System.err</code>
     </a>
   {% endif %}
@@ -20,7 +20,7 @@
   <ul class="testcase-list">
 
   {% if testsuite.system_out %}
-  <div class="collapse" id="toggleSystemOut{{ forloop.counter }}">
+  <div class="collapse" id="stdout-{{ forloop.counter }}">
   <li>
     <h5><code>System.out</code> contains:</h5>
     <pre class="console-output"><code>{{ testsuite.system_out }}</code></pre>
@@ -28,7 +28,7 @@
   </div>
   {% endif %}
   {% if testsuite.system_err %}
-  <div class="collapse" id="toggleSystemErr{{ forloop.counter }}">
+  <div class="collapse" id="stderr-{{ forloop.counter }}">
   <li>
     <h5><code>System.err</code> contains:</h5>
     <pre class="console-output"><code>{{ testsuite.system_err }}</code></pre>
@@ -48,13 +48,13 @@
   {% else %}
 
   <li class="bottom-spaced">
-    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggle{{ forloop.counter }}">
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#stacktrace-{{ forloop.counter }}">
       <div class="glyphicon glyphicon-remove inline text-danger"></div>
       <h5 class="inline">{% firstof tc.failure.message tc.error.message %}</h5>
     </a>
   </li>
 
-  <div class="collapse" id="toggle{{ forloop.counter }}">
+  <div class="collapse" id="stacktrace-{{ forloop.counter }}">
     {% if tc.failure.stacktrace or tc.error.stacktrace %}
     {% spaceless %}
     <pre class="console-output">

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -17,24 +17,20 @@
   {% endif %}
   </div>
 
-  <ul class="testcase-list">
-
   {% if testsuite.system_out %}
   <div class="collapse" id="stdout-{{ forloop.counter }}">
-  <li>
     <h5><code>System.out</code> contains:</h5>
     <pre class="console-output"><code>{{ testsuite.system_out }}</code></pre>
-  </li>
   </div>
   {% endif %}
   {% if testsuite.system_err %}
   <div class="collapse" id="stderr-{{ forloop.counter }}">
-  <li>
     <h5><code>System.err</code> contains:</h5>
     <pre class="console-output"><code>{{ testsuite.system_err }}</code></pre>
-  </li>
   </div>
   {% endif %}
+
+  <ul class="testcase-list">
 
   {% for tc in testsuite.testcases %}
 
@@ -52,17 +48,16 @@
       <div class="glyphicon glyphicon-remove inline text-danger"></div>
       <h5 class="inline">{% firstof tc.failure.message tc.error.message %}</h5>
     </a>
+    <div class="collapse" id="stacktrace-{{ forloop.counter }}">
+      {% if tc.failure.stacktrace or tc.error.stacktrace %}
+      {% spaceless %}
+      <pre class="console-output">
+        <code>{% firstof tc.failure.stacktrace tc.error.stacktrace %}</code>
+      </pre>
+      {% endspaceless %}
+      {% endif %}
+    </div>
   </li>
-
-  <div class="collapse" id="stacktrace-{{ forloop.counter }}">
-    {% if tc.failure.stacktrace or tc.error.stacktrace %}
-    {% spaceless %}
-    <pre class="console-output">
-      <code>{% firstof tc.failure.stacktrace tc.error.stacktrace %}</code>
-    </pre>
-    {% endspaceless %}
-    {% endif %}
-  </div>
 
   {% endif %}
 

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -12,7 +12,7 @@
   {% endif %}
   {% if testsuite.system_err %}
     <a class="disguised" href="#" data-toggle="collapse" data-target="#toggleSystemErr{{ forloop.counter }}">
-    <code class="inline">System.err</code>
+      <code class="inline">System.err</code>
     </a>
   {% endif %}
   </div>
@@ -41,22 +41,17 @@
   {% if not tc.failure and not tc.error %}
 
   <li class="bottom-spaced">
-  <div class="glyphicon glyphicon-ok inline text-success"></div>
-  <h5 class="testcase-name inline">
-    <code>{{ tc.name }}()</code>
-    passed
-  </h5>
+    <div class="glyphicon glyphicon-ok inline text-success"></div>
+    <h5 class="testcase-name inline"><code>{{ tc.name }}()</code> passed</h5>
   </li>
 
   {% else %}
 
   <li class="bottom-spaced">
-  <a class="disguised" href="#" data-toggle="collapse" data-target="#toggle{{ forloop.counter }}">
-  <div class="glyphicon glyphicon-remove inline text-danger"></div>
-  <h5 class="inline">
-    {% firstof tc.failure.message tc.error.message %}
-  </h5>
-  </a>
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggle{{ forloop.counter }}">
+      <div class="glyphicon glyphicon-remove inline text-danger"></div>
+      <h5 class="inline">{% firstof tc.failure.message tc.error.message %}</h5>
+    </a>
   </li>
 
   <div class="collapse" id="toggle{{ forloop.counter }}">

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -34,18 +34,13 @@
 
   {% for tc in testsuite.testcases %}
 
-  {% if not tc.failure and not tc.error %}
-
   <li class="bottom-spaced">
+  {% if not tc.failure and not tc.error %}
     <h5 class="testcase-name inline">
       <span class="glyphicon glyphicon-ok text-success"></span>
       <code>{{ tc.name }}()</code> passed
     </h5>
-  </li>
-
   {% else %}
-
-  <li class="bottom-spaced">
     <a class="disguised" href="#" data-toggle="collapse" data-target="#stacktrace-{{ forloop.counter }}">
       <h5 class="inline">
         <span class="glyphicon glyphicon-remove text-danger"></span>
@@ -61,9 +56,8 @@
       {% endspaceless %}
       {% endif %}
     </div>
-  </li>
-
   {% endif %}
+  </li>
 
   {% endfor %}
 

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -1,40 +1,78 @@
-{% for testsuite in testsuites %}
-  <h4>{{ testsuite.name }} (passed {{ testsuite.passed }} of {{ testsuite.total }})</h4>
-  <ul class="testcase-list">
-  {% for tc in testsuite.testcases %}
-    <li>
-      <h5 class="testcase-name">
-        <code>{{ tc.name }}()</code>
-        {% if not tc.failure and not tc.error %}
-          passed
-        {% else %}
-          failed with:
-        {% endif %}
-      </h5>
-      {% if tc.failure.stacktrace or tc.error.stacktrace %}
-      {% spaceless %}
-      <pre class="console-output">
-        <code>{% firstof tc.failure.stacktrace tc.error.stacktrace %}</code>
-      </pre>
-      {% endspaceless %}
-      {% endif %}
-    </li>
-  {% endfor %}
+{% if not testsuites %}
+Nothing to show here.
+{% endif %}
 
+{% for testsuite in testsuites %}
+  <div class="bottom-spaced">
+  <h4 class="inline">{{ testsuite.name }} (passed {{ testsuite.passed }} of {{ testsuite.total }})</h4>
   {% if testsuite.system_out %}
-    <li>
-      <h5><code>System.out</code> contains:</h5>
-      <pre class="console-output"><code>{{ testsuite.system_out }}</code></pre>
-    </li>
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggleSystemOut{{ forloop.counter }}">
+      <code class="inline">System.out</code>
+    </a>
   {% endif %}
   {% if testsuite.system_err %}
-    <li>
-      <h5><code>System.err</code> contains:</h5>
-      <pre class="console-output"><code>{{ testsuite.system_err }}</code></pre>
-    </li>
+    <a class="disguised" href="#" data-toggle="collapse" data-target="#toggleSystemErr{{ forloop.counter }}">
+    <code class="inline">System.err</code>
+    </a>
+  {% endif %}
+  </div>
+
+  <ul class="testcase-list">
+
+  {% if testsuite.system_out %}
+  <div class="collapse" id="toggleSystemOut{{ forloop.counter }}">
+  <li>
+    <h5><code>System.out</code> contains:</h5>
+    <pre class="console-output"><code>{{ testsuite.system_out }}</code></pre>
+  </li>
+  </div>
+  {% endif %}
+  {% if testsuite.system_err %}
+  <div class="collapse" id="toggleSystemErr{{ forloop.counter }}">
+  <li>
+    <h5><code>System.err</code> contains:</h5>
+    <pre class="console-output"><code>{{ testsuite.system_err }}</code></pre>
+  </li>
+  </div>
   {% endif %}
 
+  {% for tc in testsuite.testcases %}
+
+  {% if not tc.failure and not tc.error %}
+
+  <li class="bottom-spaced">
+  <div class="glyphicon glyphicon-ok inline text-success"></div>
+  <h5 class="testcase-name inline">
+    <code>{{ tc.name }}()</code>
+    passed
+  </h5>
+  </li>
+
+  {% else %}
+
+  <li class="bottom-spaced">
+  <a class="disguised" href="#" data-toggle="collapse" data-target="#toggle{{ forloop.counter }}">
+  <div class="glyphicon glyphicon-remove inline text-danger"></div>
+  <h5 class="inline">
+    {% firstof tc.failure.message tc.error.message %}
+  </h5>
+  </a>
+  </li>
+
+  <div class="collapse" id="toggle{{ forloop.counter }}">
+    {% if tc.failure.stacktrace or tc.error.stacktrace %}
+    {% spaceless %}
+    <pre class="console-output">
+      <code>{% firstof tc.failure.stacktrace tc.error.stacktrace %}</code>
+    </pre>
+    {% endspaceless %}
+    {% endif %}
+  </div>
+
+  {% endif %}
+
+  {% endfor %}
+
   </ul>
-{% empty %}
-  <p>Nothing to show here.</p>
+
 {% endfor %}

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -37,16 +37,20 @@
   {% if not tc.failure and not tc.error %}
 
   <li class="bottom-spaced">
-    <div class="glyphicon glyphicon-ok inline text-success"></div>
-    <h5 class="testcase-name inline"><code>{{ tc.name }}()</code> passed</h5>
+    <h5 class="testcase-name inline">
+      <span class="glyphicon glyphicon-ok text-success"></span>
+      <code>{{ tc.name }}()</code> passed
+    </h5>
   </li>
 
   {% else %}
 
   <li class="bottom-spaced">
     <a class="disguised" href="#" data-toggle="collapse" data-target="#stacktrace-{{ forloop.counter }}">
-      <div class="glyphicon glyphicon-remove inline text-danger"></div>
-      <h5 class="inline">{% firstof tc.failure.message tc.error.message %}</h5>
+      <h5 class="inline">
+        <span class="glyphicon glyphicon-remove text-danger"></span>
+        {% firstof tc.failure.message tc.error.message %}
+      </h5>
     </a>
     <div class="collapse" id="stacktrace-{{ forloop.counter }}">
       {% if tc.failure.stacktrace or tc.error.stacktrace %}

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -51,7 +51,7 @@
     <div class="collapse" id="stacktrace-{{ forloop.counter }}">
       {% if tc.failure.stacktrace or tc.error.stacktrace %}
       {% spaceless %}
-      <pre class="console-output">
+      <pre class="console-output stacktrace">
         <code>{% firstof tc.failure.stacktrace tc.error.stacktrace %}</code>
       </pre>
       {% endspaceless %}

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -1,5 +1,5 @@
 {% if not testsuites %}
-Nothing to show here.
+<p>Nothing to show here.</p>
 {% endif %}
 
 {% for testsuite in testsuites %}

--- a/inloop/solutions/templates/solutions/includes/testsuites.html
+++ b/inloop/solutions/templates/solutions/includes/testsuites.html
@@ -44,6 +44,7 @@
     <a class="disguised" href="#" data-toggle="collapse" data-target="#stacktrace-{{ forloop.counter }}">
       <h5 class="inline">
         <span class="glyphicon glyphicon-remove text-danger"></span>
+        <code>{{ tc.name }}()</code> failed:
         {% firstof tc.failure.message tc.error.message %}
       </h5>
     </a>


### PR DESCRIPTION
Fixes: #237 

Here are some screenshots showing the new design. Failed tests now don't show the full console output by default. The output of a failed test now gives a small hint by showing the kind of exception that occured. A user can now click on the Exception title and by that extend the full stacktrace. (See screenshots)

<img width="1552" alt="bildschirmfoto 2018-11-18 um 11 12 28" src="https://user-images.githubusercontent.com/27271818/48671064-df259e00-eb22-11e8-83bd-148a31868899.png">

<img width="1552" alt="bildschirmfoto 2018-11-18 um 11 15 13" src="https://user-images.githubusercontent.com/27271818/48671087-404d7180-eb23-11e8-9c27-491245fea1c4.png">

@martinmo there could be one more improvement to this issue. Instead of showing the exception type like `junit.framework.AssertionFailedError`, we could also show a short description of the failure. I tried this out already, but the problem is with styling, since the description is often very long and doesn't fit the line width. What do you think?
