### PR TITLE
Restore and refactor solution model tests

### DIFF
--- a/tests/solutions/__init__.py
+++ b/tests/solutions/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+
+SAMPLES_PATH = Path(__file__).parent.joinpath("samples")

--- a/tests/solutions/mixins.py
+++ b/tests/solutions/mixins.py
@@ -24,8 +24,7 @@ class SimpleTaskData:
 
 class SolutionsData(SimpleAccountsData, SimpleTaskData):
     """
-    Set up two solutions, one of which failed
-    and the other one succeeded.
+    Set up simple solutions.
     """
     @classmethod
     def setUpTestData(cls):

--- a/tests/solutions/test_models.py
+++ b/tests/solutions/test_models.py
@@ -1,101 +1,58 @@
-# flake8: noqa
-# pylint: disable=all
-from unittest import skip
+from unittest.mock import Mock
 
 from django.test import TestCase
+from django.utils import timezone
+
+from inloop.solutions.models import Solution, get_upload_path
+
+from tests.solutions.mixins import SolutionsData
 
 
-# XXX: this beast needs to split up
-# XXX: override MEDIA_ROOT with a temporary dir (setUp()/tearDown())
-@skip
-class HugeSteamingPileOfCrapMonolithModelTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.solution = self.create_solution()
-        self.solutionfile = self.create_solution_file(solution=self.solution)
-
-    def create_mock_checker(self, return_value):
-        checker = mock.MagicMock()
-        checker.check_task = mock.MagicMock(return_value=return_value)
-        return checker
-
+class SolutionsModelTest(SolutionsData, TestCase):
     def test_precondition(self):
-        """Verify there are no results before calling TaskSolution.do_check()."""
-        self.assertEqual(self.solution.checkerresult_set.count(), 0)
-        self.assertFalse(self.solution.passed)
-
-    def test_checkerresult_saved(self):
-        """Test if the CheckerResult is saved with the right values."""
-        self.solution.do_check(self.create_mock_checker(
-            ResultTuple(0, "OUT", "ERR", 1.2, dict())
-        ))
-
-        result_set = self.solution.checkerresult_set
-        self.assertEqual(result_set.count(), 1)
-
-        result = result_set.first()
-        self.assertEqual(result.stdout, "OUT")
-        self.assertEqual(result.stderr, "ERR")
-        self.assertEqual(result.return_code, 0)
-        self.assertEqual(result.time_taken, 1.2)
-
-        self.assertTrue(self.solution.passed)
-
-    def test_checkeroutputs_saved(self):
-        """Test if CheckerOutputs are saved."""
-        self.solution.do_check(self.create_mock_checker(
-            ResultTuple(1, "OUT", "ERR", 0.2, {"test.txt": "content", "test2.txt": "content2"})
-        ))
-
-        output_set = self.solution.checkerresult_set.first().checkeroutput_set
-        self.assertEqual(output_set.count(), 2)
-        self.assertEqual(output_set.filter(name="test.txt").count(), 1)
-        self.assertEqual(output_set.filter(name="test2.txt").count(), 1)
-        self.assertEqual(output_set.filter(name="test.txt").first().output, "content")
-        self.assertEqual(output_set.filter(name="test2.txt").first().output, "content2")
-
-    def test_failure_means_not_passed(self):
-        """Test if non-zero rc marks the solution as not passed."""
-        self.solution.do_check(self.create_mock_checker(
-            ResultTuple(1, "OUT", "ERR", 0.2, dict())
-        ))
-        results = self.solution.checkerresult_set.all()
-        self.assertEqual(results.count(), 1)
-        self.assertFalse(self.solution.passed)
-
-    def test_solution_input_is_used(self):
-        """Test if TaskSolutionFiles are passed to the Checker."""
-        checker = self.create_mock_checker(
-            ResultTuple(0, "OUT", "ERR", 1.2, dict())
-        )
-        self.solution.do_check(checker)
-        checker.check_task.assert_called_with(
-            self.task_defaults["name"],
-            path.dirname(self.solutionfile.file.path)
-        )
+        """Verify there are no results before checking."""
+        self.assertEqual(self.failed_solution.testresult_set.count(), 0)
+        self.assertFalse(self.failed_solution.passed)
 
     def test_get_upload_path(self):
-        solution = self.create_solution()
-        tsf = self.create_solution_file(solution=solution)
-        self.assertRegex(
-            models.get_upload_path(tsf, tsf.filename),
-            (r"solutions/chuck_norris/published-task/"
-             "[\d]{4}/[\d]{2}/[\d]{2}/[\d]{2}_[\d]{1,2}_[\d]+/HelloWorld.java")
-        )
+        """Test the upload path for solution files."""
+
+        # Create a mock solution to check its
+        # computed upload path
+        mock = Mock()
+        mock.solution.submission_date.year = "1970"
+        mock.solution.task.slug = "here-be-dragons"
+        mock.solution.author = "Mr. Mustermann"
+        mock.solution.id = "123456"
+
+        upload_path = get_upload_path(mock, "Fibonacci.java")
+        self.assertTrue(upload_path.startswith("solutions"))
+        self.assertTrue(upload_path.endswith("Fibonacci.java"))
+
+        tokens = upload_path.split("/")
+        for token in ["1970", "here-be-dragons", "123456"]:
+            self.assertTrue(token in tokens)
 
     def test_solution_default_status(self):
-        solution = self.create_solution()
-        self.assertFalse(solution.checkerresult_set.exists())
-        self.assertEqual(solution.status(), "pending")
+        """Verify that the default status of a solution is pending."""
+
+        # Both failed_solution and passed_solution were not checked yet
+        # so their status should be pending
+        self.assertEqual(self.failed_solution.status(), "pending")
+        self.assertEqual(self.passed_solution.status(), "pending")
 
     def test_solution_lost_status(self):
-        solution = self.create_solution()
-        mocked_time = timezone.now() + timezone.timedelta(minutes=6)
-        with mock.patch("django.utils.timezone.now", return_value=mocked_time):
-            self.assertFalse(solution.checkerresult_set.exists())
-            self.assertEqual(solution.status(), "lost")
-
-    def test_solution_failure_status(self):
-        solution = self.create_solution()
-        solution.checkerresult_set.add(CheckerResult(), bulk=False)
-        self.assertEqual(solution.status(), "failure")
+        """
+        Verify that a solution is lost when it was not processed
+        in a reasonable amount of time.
+        """
+        delayed_solution = Solution.objects.create(
+            author=self.bob,
+            task=self.task,
+            passed=False,
+        )
+        # Simulate that the solution was submitted one hour ago.
+        # The solution should therefore be marked as lost.
+        mocked_time = timezone.now() - timezone.timedelta(hours=1)
+        delayed_solution.submission_date = mocked_time
+        self.assertEqual(delayed_solution.status(), "lost")


### PR DESCRIPTION
Fixes: #240 

I removed the old solution model tests and tried to restore as many as possible of them. @martinmo as discussed, I was not able to test the solution checker because of the File problems we already looked at. If you want to @martinmo, we can try to fix this problem together before merging this PR. But, from my current perspective, it would be ineffective for to invest additional hours on this problem myself. 

I added a new `tools` file to the test folder, because I needed to create a helper class and didn't know where to put it elsewhere. The `tools` file now contains a helper class called `MockDict`:

```python
class MockDict(dict):
    """
    Make it more efficient to create mock objects.
    Use the notation MockDict({...}) to
    access any key of the passed dictionary with
    a dot to simulate the existance of the
    model object to be tested.
    """
    __getattr__ = dict.get
    __setattr__ = dict.__setitem__
    __delattr__ = dict.__delitem__
```

This class allows us to create more efficient mocks. On conventional dicts, it is not possible to access keys by the `.` operator. With this class, it is now possible to create a `.`-accessible dictionary for mock testing purposes. @martinmo do you know a more efficient or maybe even *builtin* way of doing this (?):

```python
mock_dict = MockDict({"foo": "bar"})
# Value accesible through dot operator
bar = mock_dict.foo
```

