### PR TITLE
Semester-based Date Filters in Admin Views

### DIFF
--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -47,19 +47,14 @@ class SemesterFieldListFilter(admin.DateFieldListFilter):
         semesters = []
 
         for year in range(first_solution_year, current_year + 1):
-            semesters.append(
-                ("Summer Semester {}".format(year), {
-                    self.lookup_kwarg_since: start_of_summer_semester(year),
-                    self.lookup_kwarg_until: start_of_winter_semester(year)
-                })
-            )
-
-            semesters.append(
-                ("Winter Semester {}".format(year), {
-                    self.lookup_kwarg_since: start_of_winter_semester(year),
-                    self.lookup_kwarg_until: start_of_summer_semester(year + 1)
-                })
-            )
+            semesters.append(("Summer Semester {}".format(year), {
+                self.lookup_kwarg_since: start_of_summer_semester(year),
+                self.lookup_kwarg_until: start_of_winter_semester(year)
+            }))
+            semesters.append(("Winter Semester {}".format(year), {
+                self.lookup_kwarg_since: start_of_winter_semester(year),
+                self.lookup_kwarg_until: start_of_summer_semester(year + 1)
+            }))
 
         return semesters
 
@@ -83,12 +78,10 @@ class LastMonthsDateFieldFilter(admin.DateFieldListFilter):
         """Derive last 12 months."""
         months = []
         for (year, month) in LastMonthsDateFieldFilter.get_last_months():
-            months.append(
-                ("{} {}".format(calendar.month_abbr[month], year), {
-                    self.lookup_kwarg_since: start_of_month(year, month),
-                    self.lookup_kwarg_until: end_of_month(year, month)
-                })
-            )
+            months.append(("{} {}".format(calendar.month_abbr[month], year), {
+                self.lookup_kwarg_since: start_of_month(year, month),
+                self.lookup_kwarg_until: end_of_month(year, month)
+            }))
         return months
 
 

--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -32,17 +32,16 @@ class SolutionFileInline(admin.StackedInline):
 
 class SemesterFieldListFilter(admin.DateFieldListFilter):
     def __init__(self, *args, **kwargs):
-        super(SemesterFieldListFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.title = "semester"
         self.links = self.generate_links()
 
     def generate_links(self):
         """Derive semesters of submitted solutions."""
-        solutions = Solution.objects.all().order_by("submission_date")
-        if not solutions:
+        first_solution = Solution.objects.first()
+        if not first_solution:
             return []
-        first_solution_submission_date = solutions[0].submission_date.date()
-        first_solution_year = first_solution_submission_date.year
+        first_solution_year = first_solution.submission_date.year
         current_year = timezone.now().year
         semesters = []
 
@@ -61,10 +60,9 @@ class SemesterFieldListFilter(admin.DateFieldListFilter):
 
 class LastMonthsDateFieldFilter(admin.DateFieldListFilter):
     def __init__(self, *args, **kwargs):
-        super(LastMonthsDateFieldFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.title = "month"
-        self.links = list(self.links)
-        self.links += self.generate_links()
+        self.links = list(self.links) + self.generate_links()
 
     @staticmethod
     def get_last_months():
@@ -110,7 +108,7 @@ class SolutionAdmin(admin.ModelAdmin):
         return '<a href="%s">%s details</a>' % (obj.get_absolute_url(), obj)
 
     def changelist_view(self, request, extra_context=None):
-        """Filter admin view by the selected viewport filter"""
+        """Filter admin view by the selected viewport filter."""
         solutions = Solution.objects.filter(**request.GET.dict())
         extra = {}
         if solutions:

--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -40,7 +40,7 @@ class SemesterFieldListFilter(admin.DateFieldListFilter):
         """Derive semesters of submitted solutions."""
         solutions = Solution.objects.all().order_by("submission_date")
         if not solutions:
-            return None
+            return []
         first_solution_submission_date = solutions[0].submission_date.date()
         first_solution_year = first_solution_submission_date.year
         current_year = timezone.now().year

--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -1,13 +1,95 @@
+import calendar
+
 from django.contrib import admin
+from django.utils import timezone
 
 from inloop.solutions.models import Solution, SolutionFile
 from inloop.solutions.statistics import Statistics
+
+
+def start_of_summer_semester(year):
+    return str(timezone.localdate(timezone.now()).replace(year=year, month=4, day=1))
+
+
+def start_of_winter_semester(year):
+    return str(timezone.localdate(timezone.now()).replace(year=year, month=10, day=1))
+
+
+def start_of_month(year, month):
+    return str(timezone.localdate(timezone.now()).replace(year=year, month=month, day=1))
+
+
+def end_of_month(year, month):
+    month = month % 12 + 1
+    return str(timezone.localdate(timezone.now()).replace(year=year, month=month, day=1))
 
 
 class SolutionFileInline(admin.StackedInline):
     model = SolutionFile
     readonly_fields = ['file']
     max_num = 0
+
+
+class SemesterFieldListFilter(admin.DateFieldListFilter):
+    def __init__(self, *args, **kwargs):
+        super(SemesterFieldListFilter, self).__init__(*args, **kwargs)
+        self.title = "semester"
+        self.links = self.generate_links()
+
+    def generate_links(self):
+        """Derive semesters of submitted solutions."""
+        solutions = Solution.objects.all().order_by("submission_date")
+        if not solutions:
+            return None
+        first_solution_submission_date = solutions[0].submission_date.date()
+        first_solution_year = first_solution_submission_date.year
+        current_year = timezone.now().year
+        semesters = []
+
+        for year in range(first_solution_year, current_year + 1):
+            semesters.append(
+                ("Summer Semester {}".format(year), {
+                    self.lookup_kwarg_since: start_of_summer_semester(year),
+                    self.lookup_kwarg_until: start_of_winter_semester(year)
+                })
+            )
+
+            semesters.append(
+                ("Winter Semester {}".format(year), {
+                    self.lookup_kwarg_since: start_of_winter_semester(year),
+                    self.lookup_kwarg_until: start_of_summer_semester(year + 1)
+                })
+            )
+
+        return semesters
+
+
+class LastMonthsDateFieldFilter(admin.DateFieldListFilter):
+    def __init__(self, *args, **kwargs):
+        super(LastMonthsDateFieldFilter, self).__init__(*args, **kwargs)
+        self.title = "month"
+        self.links = list(self.links)
+        self.links += self.generate_links()
+
+    @staticmethod
+    def get_last_months():
+        solutions = Solution.objects.all()
+        months = set()
+        for solution in solutions:
+            months.add((solution.submission_date.year, solution.submission_date.month))
+        return months
+
+    def generate_links(self):
+        """Derive last 12 months."""
+        months = []
+        for (year, month) in LastMonthsDateFieldFilter.get_last_months():
+            months.append(
+                ("{} {}".format(calendar.month_abbr[month], year), {
+                    self.lookup_kwarg_since: start_of_month(year, month),
+                    self.lookup_kwarg_until: end_of_month(year, month)
+                })
+            )
+        return months
 
 
 @admin.register(Solution)
@@ -19,7 +101,13 @@ class SolutionAdmin(admin.ModelAdmin):
     change_list_template = "admin/solutions/solutions.html"
     inlines = [SolutionFileInline]
     list_display = ['id', 'author', 'task', 'submission_date', 'passed', 'site_link']
-    list_filter = ['passed', 'task__category', 'submission_date', 'task']
+    list_filter = [
+        'passed',
+        'task__category',
+        ('submission_date', SemesterFieldListFilter),
+        ('submission_date', LastMonthsDateFieldFilter),
+        'task'
+    ]
     search_fields = [
         'author__username', 'author__email', 'author__first_name', 'author__last_name'
     ]
@@ -29,7 +117,7 @@ class SolutionAdmin(admin.ModelAdmin):
         return '<a href="%s">%s details</a>' % (obj.get_absolute_url(), obj)
 
     def changelist_view(self, request, extra_context=None):
-        # Filter our admin view by the selected viewport filter
+        """Filter admin view by the selected viewport filter"""
         solutions = Solution.objects.filter(**request.GET.dict())
         extra = {}
         if solutions:

--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -31,16 +31,16 @@ class SemesterFieldListFilter(admin.DateFieldListFilter):
 
     def generate_links(self):
         """Derive semesters of submitted solutions."""
+        semesters = [('Any semester', {})]
         first_solution = Solution.objects.first()
         if not first_solution:
-            return []
+            return semesters
 
         # start and end are both in the CEST timezone
         tzinfo_cest = timezone(timedelta(hours=2))
         summer_start = datetime(2018, 4, 1, tzinfo=tzinfo_cest)
         winter_start = datetime(2018, 10, 1, tzinfo=tzinfo_cest)
 
-        semesters = []
         for year in range(first_solution.submission_date.year, now().year + 1):
             semesters.append(("Summer {}".format(year), {
                 self.lookup_kwarg_since: str(summer_start.replace(year)),

--- a/inloop/solutions/admin.py
+++ b/inloop/solutions/admin.py
@@ -1,20 +1,10 @@
-import calendar
 from datetime import datetime, timedelta, timezone
 
 from django.contrib import admin
-from django.utils.timezone import localdate, now
+from django.utils.timezone import now
 
 from inloop.solutions.models import Solution, SolutionFile
 from inloop.solutions.statistics import Statistics
-
-
-def start_of_month(year, month):
-    return str(localdate(now()).replace(year=year, month=month, day=1))
-
-
-def end_of_month(year, month):
-    month = month % 12 + 1
-    return str(localdate(now()).replace(year=year, month=month, day=1))
 
 
 class SolutionFileInline(admin.StackedInline):
@@ -53,31 +43,6 @@ class SemesterFieldListFilter(admin.DateFieldListFilter):
         return semesters
 
 
-class LastMonthsDateFieldFilter(admin.DateFieldListFilter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.title = "month"
-        self.links = list(self.links) + self.generate_links()
-
-    @staticmethod
-    def get_last_months():
-        solutions = Solution.objects.all()
-        months = set()
-        for solution in solutions:
-            months.add((solution.submission_date.year, solution.submission_date.month))
-        return months
-
-    def generate_links(self):
-        """Derive last 12 months."""
-        months = []
-        for (year, month) in LastMonthsDateFieldFilter.get_last_months():
-            months.append(("{} {}".format(calendar.month_abbr[month], year), {
-                self.lookup_kwarg_since: start_of_month(year, month),
-                self.lookup_kwarg_until: end_of_month(year, month)
-            }))
-        return months
-
-
 @admin.register(Solution)
 class SolutionAdmin(admin.ModelAdmin):
     class Media:
@@ -91,7 +56,7 @@ class SolutionAdmin(admin.ModelAdmin):
         'passed',
         'task__category',
         ('submission_date', SemesterFieldListFilter),
-        ('submission_date', LastMonthsDateFieldFilter),
+        'submission_date',
         'task'
     ]
     search_fields = [


### PR DESCRIPTION
Fixes: #230

@martinmo please do not merge this PR *yet*.

I created a new `SemesterFilter` which inherits from `admin.SimpleListFilter`. This filter can be dynamically included in the model-admin. It has two functions: `lookups`, which returns a list of possible filter options and `queryset`, which performs the filtering operation itself. 

However, I am facing two issues here.

1. Since the semesters at TU Dresden don’t always start and end at the same time, we should find a scalable solution to create semesters.

2. There is another issue regarding the `Statistics` which are shown in the `SolutionAdmin
`. At the moment, the statistics are created with the currently selected filter by 
```python
Solution.objects.filter(**request.GET.dict())
```
in which `**request.GET.dict()` is the passed filter parameter. However, if a `SemesterFilter` is selected, we cannot filter this queryset by the parameter `semester`, because there is no corresponding `semester` attribute on the `Solution` model. 

Hence, a solution for both could be to create a `Semester` model handleable in an Admin View and creating a `semester` attribute in the `Solution` model (either as a field, or as a computed property). Do you see any other possibility @martinmo?