### PR TITLE
Improve console output

### DIFF
--- a/inloop/solutions/templates/solutions/solution_detail.html
+++ b/inloop/solutions/templates/solutions/solution_detail.html
@@ -128,18 +128,18 @@
   </div><!-- /#files -->
 
   <div role="tabpanel" class="tab-pane" id="console">
+  {% spaceless %}
+  <pre class="console-output">
   {% if result.stdout %}
-    <pre class="console-output">
-      <code>{{ result.stdout }}</code>
-    </pre>
+    <code>{{ result.stdout }}</code>
   {% endif %}
   {% if result.stderr %}
-    <pre class="console-output bg-danger text-white">
-      <code>{{ result.stderr }}</code>
-    </pre>
+    <code>{{ result.stderr }}</code>
   {% elif not result.stdout %}
     <p>Nothing to show here.</p>
   {% endif %}
+  </pre>
+  {% endspaceless %}
   </div><!-- /#console -->
 
   <div role="tabpanel" class="tab-pane" id="unittests">

--- a/inloop/testrunner/runner.py
+++ b/inloop/testrunner/runner.py
@@ -143,8 +143,9 @@ class DockerTestRunner:
 
         LOG.debug("Popen args: %s", args)
 
+        # Pipe stderr to stdout to interleave both streams
         proc = subprocess.Popen(
-            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
 
         try:
@@ -160,8 +161,14 @@ class DockerTestRunner:
             LOG.debug("removing timed out container %s", ctr_id)
             subprocess.call(["docker", "rm", "--force", str(ctr_id)], stdout=subprocess.DEVNULL)
 
-        stderr = stderr.decode("utf-8", errors="replace")
-        stdout = stdout.decode("utf-8", errors="replace")
+        if stderr:
+            stderr = stderr.decode("utf-8", errors="replace")
+        else:
+            stderr = ""
+        if stdout:
+            stdout = stdout.decode("utf-8", errors="replace")
+        else:
+            stdout = ""
 
         LOG.debug("container %s: rc=%r stdout=%r stderr=%r", ctr_id, rc, stdout, stderr)
 

--- a/tests/testrunner/tests.py
+++ b/tests/testrunner/tests.py
@@ -58,8 +58,12 @@ class DockerTestRunnerTests(TestCase):
             DATA_DIR
         )
         self.assertEqual(result.rc, 42)
-        self.assertEqual(result.stdout, "OUT")
-        self.assertEqual(result.stderr, "ERR")
+        # Stdout should contain both OUT and ERR,
+        # because they are interleaved
+        self.assertEqual(result.stdout, "OUTERR")
+        # Stderr should default to "", even if
+        # nothing is piped to stderr
+        self.assertEqual(result.stderr, "")
         self.assertGreaterEqual(result.duration, 0.0)
 
     def test_kill_on_timeout(self):
@@ -76,8 +80,8 @@ class DockerTestRunnerTests(TestCase):
             DATA_DIR
         )
         self.assertEqual(result.rc, signal.SIGKILL)
-        self.assertEqual(result.stdout, "OUT")
-        self.assertEqual(result.stderr, "ERR")
+        self.assertEqual(result.stdout, "OUTERR")
+        self.assertEqual(result.stderr, "")
 
     def test_inbound_mountpoint(self):
         """Test if the input mount point works correctly."""

--- a/tests/testrunner/tests.py
+++ b/tests/testrunner/tests.py
@@ -66,6 +66,19 @@ class DockerTestRunnerTests(TestCase):
         self.assertEqual(result.stderr, "")
         self.assertGreaterEqual(result.duration, 0.0)
 
+    def test_output_interleaved(self):
+        """Test if stdout and stderr are interleaved correctly."""
+        result = self.runner.check_task(
+            "echo -n OUT; echo -n ERR >&2; echo -n OUT; exit 42",
+            DATA_DIR
+        )
+        self.assertEqual(result.rc, 42)
+        # Stdout should contain OUT, ERR and OUT
+        # appended to each other in the correct order
+        self.assertEqual(result.stdout, "OUTERROUT")
+        self.assertEqual(result.stderr, "")
+        self.assertGreaterEqual(result.duration, 0.0)
+
     def test_kill_on_timeout(self):
         """Test if the container gets killed after the timeout."""
         result = self.runner.check_task("sleep 10", DATA_DIR)


### PR DESCRIPTION
Fixes: #236 

Hi @martinmo, I removed the erroneous whitespacing and visually combined the `stderr` with the `stdout` of a TestResult in the console output view. 

However, I don't know exactly how much it would affect the stability of the deployed system if we'd remove the `stderr` attribute on the `TestResult` model. So what I simply did is to pipe the stderr output of a testrun to `stdout`:

```python
proc = subprocess.Popen(
    args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
)
```

This interleaves the `stderr` output with the `stdout` output. However, there will be no more `stderr`.

@martinmo so my question is, can I remove the `stderr` attribute of `TestResult` and how would that affect our deployed system? With that done, I could simply return the output instead of both `stderr` and `stdout` separately and store it into the `stdout` attribute all at once. Of course, this would make a template change necessary. Implementation-wise, this should all be no problem since I already made migrations before, but I wanted to simply ask before performing potential risky changes.