### PR TITLE
Add a way to generate submissions

### DIFF
--- a/inloop/solutions/management/commands/generate_submissions.py
+++ b/inloop/solutions/management/commands/generate_submissions.py
@@ -1,0 +1,106 @@
+import random
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db.transaction import atomic
+from django.utils.timezone import make_aware
+
+from inloop.solutions.models import Solution
+from inloop.tasks.models import Task
+
+User = get_user_model()
+
+file_dir = Path(__file__).resolve().parent
+
+
+class Command(BaseCommand):
+    help = "Generate submissions for demo purposes."
+
+    dateformat = "%d.%m.%Y"
+    help_text_safe_dateformat = "dd.mm.YYYY"
+
+    def create_users(self, number):
+        users = []
+        for i in range(number):
+            username = "GeneratedUser{}".format(i)
+            email = "generated-user-{}@example.com".format(i)
+            password = "secret"
+            user, _ = User.objects.get_or_create(
+                username=username, email=email, password=password
+            )
+            users.append(user)
+        return users
+
+    def create_solution(self, user, task, start_date, end_date):
+        passed = random.choice([True, False])
+        seconds_until_end_date = int((end_date - start_date).total_seconds())
+        submission_date = start_date + timedelta(
+            seconds=random.randint(0, seconds_until_end_date)
+        )
+        solution = Solution.objects.create(
+            author=user, task=task, passed=passed,
+        )
+        # Because of auto_now_add, we can't set a custom
+        # submission_date through the constructor
+        solution.submission_date = submission_date
+        solution.save()
+        return solution
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--start_date",
+            help="Start date (Format: {})".format(self.help_text_safe_dateformat),
+            default=(datetime.now() - timedelta(days=365)).strftime(self.dateformat),
+        )
+        parser.add_argument(
+            "--end_date",
+            help="End date (Format: {})".format(self.help_text_safe_dateformat),
+            default=datetime.now().strftime(self.dateformat),
+        )
+        parser.add_argument(
+            "--solutions_number",
+            help="Number of solutions to generate",
+            type=int,
+            default=1000
+        )
+        parser.add_argument(
+            "--users_number",
+            help="Number of users to generate",
+            type=int,
+            default=10
+        )
+        parser.add_argument(
+            "--force",
+            help="Immediately perform submission creation without prompt",
+            default=False
+        )
+
+    def handle(self, *args, **options):
+        start_date = make_aware(datetime.strptime(options["start_date"], self.dateformat))
+        end_date = make_aware(datetime.strptime(options["end_date"], self.dateformat))
+        solutions_number = options["solutions_number"]
+        users_number = options["users_number"]
+        verbosity = options["verbosity"]
+        force = options["force"]
+        if start_date > end_date:
+            raise ValueError("Start date should be before end date.")
+        if not Task.objects.exists():
+            raise ValueError("There are no tasks available.")
+        if not force:
+            if input("This will create user accounts and solutions. Continue? (y/n)") != "y":
+                return
+        with atomic():
+            users = self.create_users(users_number)
+            tasks = Task.objects.all()
+            all_solutions = []
+            for _ in range(solutions_number):
+                user = random.choice(users)
+                task = random.choice(tasks)
+                all_solutions.append(self.create_solution(
+                    user, task, start_date, end_date
+                ))
+        if verbosity > 0:
+            self.stdout.write("Successfully created {} users.".format(len(users)))
+            self.stdout.write("Successfully created {} solutions.".format(len(all_solutions)))

--- a/tests/solutions/test_commands.py
+++ b/tests/solutions/test_commands.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase, tag
+from django.utils.timezone import make_aware
+
+from inloop.solutions.management.commands.generate_submissions import Command
+from inloop.solutions.models import Solution
+from inloop.tasks.models import Task
+
+from tests.solutions.mixins import SimpleTaskData
+
+User = get_user_model()
+
+DATEFORMAT = Command.dateformat
+START_DATE_STR = "01.01.1970"
+END_DATE_STR = "31.12.2018"
+
+
+@tag("slow")
+class GenerateSubmissionsTest(SimpleTaskData, TestCase):
+    def test_command(self):
+        """Verify that submissions can be generated correctly."""
+        opts = {
+            "start_date": START_DATE_STR,
+            "end_date": END_DATE_STR,
+            "solutions_number": 10,
+            "users_number": 10,
+            "force": True,
+            "stdout": StringIO()
+        }
+        call_command("generate_submissions", **opts)
+
+        self.assertEqual(Solution.objects.all().count(), 10)
+        self.assertEqual(User.objects.all().count(), 10)
+
+        start_date = make_aware(datetime.strptime(START_DATE_STR, DATEFORMAT))
+        end_date = make_aware(datetime.strptime(END_DATE_STR, DATEFORMAT))
+
+        for solution in Solution.objects.all():
+            self.assertTrue(solution.submission_date > start_date)
+            self.assertTrue(solution.submission_date < end_date)
+
+    def test_force(self):
+        """Test the force flag of the management command."""
+        opts = {
+            "start_date": START_DATE_STR,
+            "end_date": END_DATE_STR,
+            "force": True,
+            "stdout": StringIO()
+        }
+        call_command("generate_submissions", **opts)
+        self.assertNotEqual(Solution.objects.all().count(), 0)
+        self.assertNotEqual(User.objects.all().count(), 0)
+
+    def test_prompt(self):
+        """
+        Verify that the user has to confirm the
+        generation of submissions first.
+        """
+        opts = {
+            "start_date": START_DATE_STR,
+            "end_date": END_DATE_STR,
+            "stdout": StringIO()
+        }
+        func_to_patch = "inloop.solutions.management.commands.generate_submissions.input"
+        with patch(func_to_patch, return_value="n"):
+            call_command("generate_submissions", **opts)
+        self.assertEqual(Solution.objects.all().count(), 0)
+        self.assertEqual(User.objects.all().count(), 0)
+
+    def test_erronenous_input_dates(self):
+        """Verify that the input dates are checked for validity."""
+        opts = {
+            "start_date": END_DATE_STR,
+            "end_date": START_DATE_STR,
+            "stdout": StringIO()
+        }
+        try:
+            call_command("generate_submissions", **opts)
+            self.fail("The management command should check the input dates for validity.")
+        except ValueError:
+            pass
+
+    def test_silent(self):
+        """Verify that command line output is only produced when needed."""
+        out = StringIO()
+        opts = {
+            "start_date": START_DATE_STR,
+            "end_date": END_DATE_STR,
+            "force": True,
+            "stdout": out,
+            "verbosity": 0
+        }
+        call_command("generate_submissions", **opts)
+        self.assertFalse(out.getvalue())
+        opts["verbosity"] = 1
+        call_command("generate_submissions", **opts)
+        self.assertTrue(out.getvalue())
+
+
+class EmptyDatabaseGenerateTest(TestCase):
+    def test_no_task(self):
+        """Verify that the command fails when there is no available task."""
+        opts = {
+            "start_date": START_DATE_STR,
+            "end_date": END_DATE_STR,
+            "force": True,
+            "stdout": StringIO()
+        }
+        self.assertEqual(Task.objects.count(), 0)
+        try:
+            call_command("generate_submissions", **opts)
+            self.fail("The management command should fail, when there are no tasks.")
+        except ValueError:
+            pass


### PR DESCRIPTION
Closes: #221 

The new management command `generate_submissions` can be used to create user submissions for demo purposes, which means that it creates `Solutions` and `Users`. The users are generated with random animal names, like in Google Docs. 

@martinmo does this meet your issue or should the command be advanced to create more object types? (e.g. `SolutionFiles`)