### PR TITLE
Improve the solutions module

### DIFF
--- a/inloop/solutions/models.py
+++ b/inloop/solutions/models.py
@@ -164,6 +164,15 @@ class Solution(models.Model):
         return "Solution #%d" % self.id
 
 
+@receiver(post_delete, sender=Solution, dispatch_uid="delete_solutionfile")
+def auto_delete_archive_on_delete(sender, instance, **kwargs):
+    """
+    Removes archive from filesystem when corresponding Solution object is deleted.
+    """
+    if instance.archive and os.path.isfile(instance.archive.path):
+        os.remove(instance.archive.path)
+
+
 class SolutionFile(models.Model):
     """Represents a single file as part of a solution."""
 

--- a/tests/solutions/test_views.py
+++ b/tests/solutions/test_views.py
@@ -115,6 +115,18 @@ class SolutionDetailViewTest(TaskData, SimpleAccountsData, TestCase):
         }), follow=True)
         self.assertEqual(response.status_code, 200)
 
+    def test_archive_access(self):
+        """Verify that a user cannot download other users' solution archives."""
+        self.assertTrue(self.client.login(username="alice", password="secret"))
+        create_archive(self.solution)
+
+        # Because the solution was created by bob, alice
+        # should not be able to access his archive
+        response = self.client.get(reverse("solutions:archive_download", kwargs={
+            "solution_id": self.solution.id
+        }), follow=True)
+        self.assertEqual(response.status_code, 404)
+
     def test_console_output(self):
         """Test console output tab in solution detail view."""
         self.assertTrue(self.client.login(username="bob", password="secret"))


### PR DESCRIPTION
Fixes: #308, #309, #310, #311.

See the meta issue #311:
- Add a test case which tests for archive access permissions.
- #309: Add a post delete signal listener, which removes solution archives after the corresponding solution was deleted.
- #310: Add a test case, which verifies that archives and solution files are deleted correctly after their corresponding solution object was deleted.