### PR TITLE
Fix overlapped headings in task details

### DIFF
--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -76,7 +76,7 @@ code {
  * Insert an invisible spacer on selected headings
  * to force them below the sticky tab bar
  */
-.static-tab-content :target:before {
+.static-tab-content :target::before {
   content: '';
   display: block;
   width: 0;

--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -72,6 +72,18 @@ code {
   color: #ddd;
 }
 
+/*
+ * Insert an invisible spacer on selected headings
+ * to force them below the sticky tab bar
+ */
+.static-tab-content :target:before {
+  content: '';
+  display: block;
+  width: 0;
+  height: 5em;
+  margin-top: -5em;
+}
+
 /* @end */
 
 /* @begin common container styles */

--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -80,8 +80,8 @@ code {
   content: '';
   display: block;
   width: 0;
-  height: 5em;
-  margin-top: -5em;
+  height: 65px;
+  margin-top: -65px;
 }
 
 /* @end */


### PR DESCRIPTION
Insert an invisible spacer on selected headings to force them below the sticky tab bar in the task details tab.
Use the :target selector to select the element, which is targeted by the current document fragment identifier.

Fixes: #346