### PR TITLE
Make archives downloadable for staff users

### DIFF
--- a/assets/js/archive-status.js
+++ b/assets/js/archive-status.js
@@ -79,7 +79,7 @@ $(document).ready(function() {
 
     class PendingArchiveDownloadBar extends DownloadBar {
         get text() {
-            return "Your archive is being created.";
+            return "The archive is being created.";
         }
 
         get css() {
@@ -109,7 +109,7 @@ $(document).ready(function() {
 
     class DownloadArchiveDownloadBar extends DownloadBar {
         get text() {
-            return "Click here to download your solution as zip archive.";
+            return "Click here to download the solution as zip archive.";
         }
 
         get css() {

--- a/inloop/solutions/templates/solutions/solution_detail.html
+++ b/inloop/solutions/templates/solutions/solution_detail.html
@@ -125,7 +125,7 @@
       {% if solution.archive %}
       <a class="list-group-item list-group-item-success"
          href="{% url 'solutions:archive_download' solution.id %}">
-        Click here to download your solution as a zip archive.
+        Click here to download the solution as a zip archive.
       </a>
       {% else %}
       <a class="list-group-item list-group-item-info" href="#"


### PR DESCRIPTION
Fix an issue, where it was denoted, that staff users cannot download other users' solution archives.
Adds a test case, which proves this assertion.

Fixes: #345 