### PR TITLE
Use scroll-margin-top to avoid tab bar overlap

### DIFF
--- a/assets/css/inloop.css
+++ b/assets/css/inloop.css
@@ -74,15 +74,11 @@ code {
 }
 
 /*
- * Insert an invisible spacer on selected headings
- * to force them below the sticky tab bar
+ * Avoid tab bar overlapping in autolinked
+ * containers by adding a scroll-only margin.
  */
-.static-tab-content :target::before {
-  content: '';
-  display: block;
-  width: 0;
-  height: 65px;
-  margin-top: -65px;
+.autolink h2, .autolink h3 {
+  scroll-margin-top: 65px;
 }
 
 /* @end */


### PR DESCRIPTION
Replaced the hack where we used the `:target` and the `::before` selector to create a top margin by inserting an element. Use the `scroll-margin-top` css feature to declare this margin without modifying the document tree hierarchy.

Closes: #346