### PR TITLE
Allow delete/rename after deleting all files

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -301,6 +301,7 @@ class TabBar {
       hashComparator.lookForChanges(fileBuilder.files);
       if (file === undefined) return;
       this.createNewTab(file);
+      this.toggleRenameDeleteButtons();
     };
     showPrompt(getString(msgs.choose_filename), fileCreationCallback);
   }


### PR DESCRIPTION
After deleting all files the delete and rename buttons in the editor got disabled. That's expected behavior. However creating new files afterwards did not re-enable the buttons. Now they get re-enabled again after creating new files.

Fixes: #374