### PR TITLE
Check whether upload exists before accessing it

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -730,7 +730,8 @@ class Toolbar {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  document.getElementById(MANUAL_UPLOAD_INPUT_ID).addEventListener("change", function () {
+  const uploadInputElement = document.getElementById(MANUAL_UPLOAD_INPUT_ID);
+  uploadInputElement && uploadInputElement.addEventListener("change", function () {
     document.getElementById(MANUAL_UPLOAD_FORM_ID).submit();
   });
 


### PR DESCRIPTION
Add check, whether the upload input element really exists before attaching an event listener to it. Needed when a deadline is expired.

Fixes: #375