### PR TITLE
Add check for readyState of document

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -748,7 +748,7 @@ class Toolbar {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function init() { 
   const uploadInputElement = document.getElementById(MANUAL_UPLOAD_INPUT_ID);
   uploadInputElement && uploadInputElement.addEventListener("change", function () {
     document.getElementById(MANUAL_UPLOAD_FORM_ID).submit();
@@ -778,4 +778,10 @@ document.addEventListener("DOMContentLoaded", () => {
     hashComparator.lookForChanges(files);
     tabBar = new TabBar(files);
   });
-});
+}
+
+if (document.readyState != "loading"){
+  init();
+} else {
+  document.addEventListener("DOMContentLoaded", () => init());
+}


### PR DESCRIPTION
Instead of only attaching a DOMContentLoaded event listener to document, the script now checks whether domReady state is not 'loading' anymore and then initializes the UI and JS logic. If the domReady state is still 'loading', the event listener is attached like before. This prevents the script from missing the event.

Fixes: #377