### PR TITLE
Show alert when leaving with unsaved changes

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -785,3 +785,12 @@ if (document.readyState != "loading"){
 } else {
   document.addEventListener("DOMContentLoaded", () => init());
 }
+
+window.addEventListener("beforeunload", (e) => {
+  if (!hashComparator.lookForChanges(fileBuilder.files)) {
+    e.preventDefault();
+    const confirmationMessage = "";
+    e.returnValue = confirmationMessage;
+    return confirmationMessage;
+  }
+});


### PR DESCRIPTION
Show a dialog box that warns the user that there are unsaved changes. The dialog only appears, when changes made to the code or new files were not saved yet. Used the "beforeunload" event of the window element. Implementation contains some legacy methods to make it work in all common browsers. 

Fixes: #391