### PR TITLE
Add <noscript> warning to editor template

### DIFF
--- a/inloop/solutions/templates/solutions/editor.html
+++ b/inloop/solutions/templates/solutions/editor.html
@@ -12,6 +12,12 @@
 {% block container_classes %}container-fluid{% endblock %}
 
 {% block content %}
+<noscript>
+  <p class="alert alert-warning">
+    Unfortunately your browser does not support JavaScript or you manually disabled JavaScript.
+    In order to use the online editor or the manual file upload JavaScript has to be enabled.
+  </p>
+</noscript>
 <header class="toolbar">
   <div>
     <h1>{{ task.title }}</h1>


### PR DESCRIPTION
The editor and the file upload only work with JS enabled. In order to
inform users, that use a browser without JS support or that disabled
JS, there will now appear a warning above the toolbar. Used the <noscript>
tag for this

Fixes: #392