### PR TITLE
Submit and save error handling

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -23,6 +23,9 @@ const TOOLBAR_BUTTONS_RIGHT_ID = "toolbar-buttons--right";
 const CONSOLE_CONTAINER_ID = "console";
 const CONSOLE_CONTENT_ID = "console-content";
 const CONSOLE_HIDE_BUTTON_ID = "console-btn--hide";
+const CURRENT_SUBMITS_DATA_KEY = "data-current-submissions";
+const MAX_SUBMITS_DATA_KEY = "data-submission-limit";
+const NO_SUBMISSION_LIMIT = -1;
 
 const msgs = {
   try_again_later: "Please try again later.",
@@ -822,7 +825,10 @@ class Toolbar {
   }
 
   setSubmitButtonEnabled(enable) {
-    this.submitButton.disabled = !enable;
+    const maxSubmissions = parseInt(this.submitButton.getAttribute(MAX_SUBMITS_DATA_KEY));
+    const currentSubmissions = parseInt(this.submitButton.getAttribute(CURRENT_SUBMITS_DATA_KEY));
+    const maySubmit = (maxSubmissions == NO_SUBMISSION_LIMIT) || (currentSubmissions < maxSubmissions);
+    this.submitButton.disabled = !(maySubmit && enable);
   }
 
   setSyntaxButtonEnabled(enable) {

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -46,7 +46,8 @@ const msgs = {
   syntax_check_successful: "Syntax check successful. No errors detected.",
   syntax_check_failed: "Syntax check failed. %amount% errors/warnings detected.",
   error_checking_syntax: "Could not check syntax. Please try again later.",
-  submission_failed: "Submission failed: %message%"
+  submission_failed: "Submission failed: %message%",
+  submission_failed_unknown: "Submission failed due to an unknown reason."
 };
 
 const EMPTY_STRING_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
@@ -787,13 +788,14 @@ class Toolbar {
         return;
       }
       if (result.success) {
-        console.log(result);
         if (result.num_submissions && result.submission_limit) {
           this.updateSubmitButton(result.num_submissions, result.submission_limit);
         }
         window.location.assign(SOLUTIONS_LIST_URL);
       } else if (result.reason) {
         showAlert(getString(msgs.submission_failed, result.reason));
+      } else {
+        showAlert(getString(msgs.submission_failed_unknown));
       }
     });
   }

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -48,6 +48,7 @@ const msgs = {
   error_submit: "Submission failed.\n%message%",
   error_save_before_submit:
     "Submission failed. Could not save files before submitting.\n%message%",
+  error_unknown: "Unknown error"
 };
 
 const EMPTY_STRING_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
@@ -810,10 +811,8 @@ class Toolbar {
         } else {
           window.location.assign(SOLUTIONS_LIST_URL);
         }
-      } else if (result.reason) {
-        showAlert(getString(msgs.error_submit, result.reason));
       } else {
-        showAlert(getString(msgs.error_submit));
+        showAlert(getString(msgs.error_submit, result.reason || msgs.error_unknown));
       }
     });
   }

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -821,6 +821,7 @@ class Toolbar {
     this.submitButton.innerText = `Submit (${currentSubmissions}/${maxSubmissions})`;
     this.submitButton.setAttribute(CURRENT_SUBMITS_DATA_KEY, currentSubmissions);
     this.submitButton.setAttribute(MAX_SUBMITS_DATA_KEY, maxSubmissions);
+    this.setSubmitButtonEnabled(currentSubmissions < maxSubmissions);
   }
 
   checkSyntax() {

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -46,7 +46,8 @@ const msgs = {
   syntax_check_failed: "Syntax check failed. %amount% errors/warnings detected.",
   error_checking_syntax: "Could not check syntax. Please try again later.",
   error_submit: "Submission failed.\n%message%",
-  error_save_before_submit: "Submission failed. Could not save files before submitting.\n%message%"
+  error_save_before_submit:
+    "Submission failed. Could not save files before submitting.\n%message%",
 };
 
 const EMPTY_STRING_SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
@@ -587,9 +588,16 @@ class Communicator {
       body: JSON.stringify(payload),
     };
     let errorMsg = "";
-    const response = await fetch(SAVE_CHECKPOINT_URL, requestConfig).catch((error) => errorMsg = error);
+    const response = await fetch(SAVE_CHECKPOINT_URL, requestConfig).catch(
+      (error) => (errorMsg = error)
+    );
     if (!response.status || response.status !== 200) {
-      showAlert(getString(saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_save, errorMsg || `${response.status} ${response.statusText}`));
+      showAlert(
+        getString(
+          saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_save,
+          errorMsg || `${response.status} ${response.statusText}`
+        )
+      );
       return;
     }
     const data = await response.json();
@@ -629,9 +637,13 @@ class Communicator {
       body: JSON.stringify(payload),
     };
     let errorMsg = "";
-    const response = await fetch(SOLUTIONS_EDITOR_URL, requestConfig).catch((error) => errorMsg = error);
+    const response = await fetch(SOLUTIONS_EDITOR_URL, requestConfig).catch(
+      (error) => (errorMsg = error)
+    );
     if (!response.status || response.status !== 200) {
-      showAlert(getString(msgs.error_submit, errorMsg || `${response.status} ${response.statusText}`));
+      showAlert(
+        getString(msgs.error_submit, errorMsg || `${response.status} ${response.statusText}`)
+      );
       return;
     }
     return await response.json();
@@ -678,7 +690,7 @@ class SyntaxCheckConsole {
       const strong = document.createElement("strong");
       strong.textContent = text;
       return strong;
-    }
+    };
     const capitalize = (text) => `${text[0].toUpperCase()}${text.slice(1)}`;
     const p = document.createElement("p");
 
@@ -788,7 +800,7 @@ class Toolbar {
   }
 
   submitFiles(files) {
-    communicator.submitFiles(files).then(result => {
+    communicator.submitFiles(files).then((result) => {
       if (!result) {
         return;
       }
@@ -858,7 +870,7 @@ class Toolbar {
   setSubmitButtonEnabled(enable) {
     const maxSubmissions = parseInt(this.submitButton.getAttribute(MAX_SUBMITS_DATA_KEY));
     const currentSubmissions = parseInt(this.submitButton.getAttribute(CURRENT_SUBMITS_DATA_KEY));
-    const maySubmit = (maxSubmissions == NO_SUBMISSION_LIMIT) || (currentSubmissions < maxSubmissions);
+    const maySubmit = maxSubmissions == NO_SUBMISSION_LIMIT || currentSubmissions < maxSubmissions;
     this.submitButton.disabled = !(maySubmit && enable);
   }
 

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -29,7 +29,6 @@ const NO_SUBMISSION_LIMIT = -1;
 
 const msgs = {
   try_again_later: "Please try again later.",
-  upload_failed: "Upload failed.",
   duplicate_filename:
     'A file with the name "%filename%" already exists.\nPlease choose another filename.',
   invalid_filename:
@@ -40,7 +39,7 @@ const msgs = {
   missing_es6_support:
     "Your browser does not support ECMAScript 6. Please update or change your browser to use the editor.",
   error_loading_files: "Error occured: Could not load saved files from server.",
-  error_saving_files: "Could not save files.\n%message%",
+  error_save: "Could not save files.\n%message%",
   deadline_expired: "Deadline expired",
   not_implemented_yet: "This functionality has not been implemented yet.",
   syntax_check_successful: "Syntax check successful. No errors detected.",
@@ -590,7 +589,7 @@ class Communicator {
     let errorMsg = "";
     const response = await fetch(SAVE_CHECKPOINT_URL, requestConfig).catch((error) => errorMsg = error);
     if (!response.status || response.status !== 200) {
-      showAlert(getString(saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_saving_files, errorMsg || `${response.status} ${response.statusText}`));
+      showAlert(getString(saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_save, errorMsg || `${response.status} ${response.statusText}`));
       return;
     }
     const data = await response.json();
@@ -598,7 +597,7 @@ class Communicator {
       hashComparator.updateHash(checksum);
       hashComparator.lookForChanges(fileBuilder.files);
     } else {
-      showAlert(getString(saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_saving_files));
+      showAlert(getString(saveBeforeSubmit ? msgs.error_save_before_submit : msgs.error_save));
       return;
     }
     if (saveBeforeSubmit) {

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -609,7 +609,7 @@ class Communicator {
   async submitFiles(files) {
     const saveResult = await this.saveFiles();
     if (!saveResult || !saveResult.success) {
-      showAlert(getString(msgs.upload_failed));
+      showAlert(getString(msgs.submission_failed_unknown));
       return;
     }
     const payload = { uploads: {} };
@@ -626,7 +626,7 @@ class Communicator {
     };
     const response = await fetch(SOLUTIONS_EDITOR_URL, requestConfig);
     if (response.status !== 200) {
-      showAlert(getString(msgs.error_saving_files));
+      showAlert(getString(msgs.submission_failed_unknown));
       return;
     }
     return await response.json();

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -788,10 +788,11 @@ class Toolbar {
         return;
       }
       if (result.success) {
-        if (result.num_submissions && result.submission_limit) {
+        if (result.skip_redirect && result.num_submissions && result.submission_limit) {
           this.updateSubmitButton(result.num_submissions, result.submission_limit);
+        } else {
+          window.location.assign(SOLUTIONS_LIST_URL);
         }
-        window.location.assign(SOLUTIONS_LIST_URL);
       } else if (result.reason) {
         showAlert(getString(msgs.submission_failed, result.reason));
       } else {

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -797,7 +797,7 @@ class Toolbar {
       } else {
         showAlert(getString(msgs.submission_failed_unknown));
       }
-    });
+    }).catch(error => showAlert(error));
   }
 
   updateSubmitButton(currentSubmissions, maxSubmissions) {


### PR DESCRIPTION
Implemented error handling for submit and save:
- catch errors thrown by fetch request, e.g. when there is no internet connection
- if any kind of error occurs, display an alert with respective information
- show specific messages when errors happen in save before submit
- update submit button after submit requests if site should not redirect (`skip_redirect == true`)
- disable submit button when max submissions are reached

Fixes: #393 