### PR TITLE
Remove bootstrap/jquery js imports in editor template

### DIFF
--- a/inloop/solutions/templates/solutions/editor.html
+++ b/inloop/solutions/templates/solutions/editor.html
@@ -120,9 +120,7 @@
 <script src="{% static 'vendor/js/ace-1.4.12/ace.js' %}"></script>
 <script src="{% static 'vendor/js/ace-1.4.12/ext-language_tools.js' %}"></script>
 <script src="{% static 'vendor/js/ace-1.4.12/mode-java.js' %}"></script>
-<script src="{% static 'vendor/js/jquery.min.js' %}"></script>
 <script src="{% static 'vendor/js/rusha.min.js' %}"></script>
-<script src="{% static 'vendor/js/bootstrap.min.js' %}"></script>
 <script src="{% static 'js/ace-theme-inloop.js' %}"></script>
 <script id="editor-script" type="module" src="{% static 'js/editor/editor.js' %}"
         data-csrf-token="{{ csrf_token }}"


### PR DESCRIPTION
Removed import of Bootstrap and jQuery JavaScript imports in editor template, because these files are already imported in the base template. That led to the problem, that Bootstrap initialized specific UI elements (e.g. dropdowns) multiple times. As a result some ui elements no longer functioned correctly.